### PR TITLE
Add missing Itch.io project entries to portfolio games list

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,9 @@
         <button onclick="scrollToGame('game11')">Downdie</button>
         <button onclick="scrollToGame('game12')">Evadrone</button>
         <button onclick="scrollToGame('game13')">Keepmoving</button>
+        <button onclick="scrollToGame('game14')">Warteg Langganan Intern</button>
+        <button onclick="scrollToGame('game15')">Butikku</button>
+        <button onclick="scrollToGame('game16')">Advergame (Cup Game)</button>
       </div>
 
       <div class="game-detail interactive-float" id="game1">
@@ -184,6 +187,33 @@
           <h3>Keepmoving</h3>
           <p>Endless rhythm runner with pixel vibes.</p>
           <a href="https://aka-shakthi.itch.io/keepmoving" target="_blank">▶️ Play on Itch.io</a>
+        </div>
+      </div>
+
+      <div class="game-detail interactive-float" id="game14">
+        <img src="img/swaraquest.jpg" class="game-thumb" alt="Warteg Langganan Intern">
+        <div class="description-block">
+          <h3>Warteg Langganan Intern</h3>
+          <p>Management simulation intern project with economy, cooking, and dynamic serving systems.</p>
+          <a href="https://aka-shakthi.itch.io/warteglanggananintern" target="_blank">▶️ Play on Itch.io</a>
+        </div>
+      </div>
+
+      <div class="game-detail interactive-float" id="game15">
+        <img src="img/swaraquest.jpg" class="game-thumb" alt="Butikku">
+        <div class="description-block">
+          <h3>Butikku</h3>
+          <p>Boutique simulation final thesis built with Unity C#, ScriptableObject inventory, and modular architecture.</p>
+          <a href="https://aka-shakthi.itch.io/butikku" target="_blank">▶️ Play on Itch.io</a>
+        </div>
+      </div>
+
+      <div class="game-detail interactive-float" id="game16">
+        <img src="img/swaraquest.jpg" class="game-thumb" alt="Advergame (Cup Game)">
+        <div class="description-block">
+          <h3>Advergame (Cup Game)</h3>
+          <p>Custom 2D advergame focused on user engagement and polished gameplay mechanics.</p>
+          <a href="https://aka-shakthi.itch.io/adverdgame" target="_blank">▶️ Play on Itch.io</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Ensure the portfolio's "My Games" section includes three projects that were missing from the website so visitors can play them directly from the portfolio. 
- Skip duplication for entries that already exist (e.g., `Swaraquest`) and only add projects that were absent.

### Description
- Added three navigation buttons to the `My Games` section for `Warteg Langganan Intern`, `Butikku`, and `Advergame (Cup Game)` in `index.html`.
- Added three corresponding `.game-detail` cards with short descriptions and Itch.io links to `index.html`.
- Reused the existing `img/swaraquest.jpg` thumbnail as a placeholder for the three new cards to avoid broken images.
- Only `index.html` was modified; no other files were changed.

### Testing
- Ran `git status --short && git diff -- index.html` to inspect the changes, which completed successfully and showed the expected diff. 
- Ran `rg -n "warteglanggananintern|butikku|adverdgame|swaraquest" index.html` to verify the new entries are present, which returned the expected matches. 
- Committed the change with `git commit -m "Add missing Itch.io project entries to My Games"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e048130ed4832396278587beebe901)