### PR TITLE
Redesign homepage: new hero, project card grid, and refreshed styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,20 +1,22 @@
 :root {
-  --bg-gradient: radial-gradient(circle at 10% 20%, #142748 0%, #08111f 45%, #05070d 100%);
+  --bg-gradient: radial-gradient(circle at 10% 20%, #182747 0%, #101a30 42%, #090d1a 100%);
   --text-color: #f4fbff;
-  --muted-text: #bdd5e4;
-  --accent: #6df6ff;
+  --muted-text: #c4d8ea;
+  --accent: #8be7ff;
+  --accent-2: #a98bff;
   --card-bg: rgba(255, 255, 255, 0.12);
-  --card-border: rgba(255, 255, 255, 0.28);
+  --card-border: rgba(255, 255, 255, 0.3);
   --shadow: 0 16px 38px rgba(6, 20, 35, 0.42);
 }
 
 html[data-theme="day"] {
-  --bg-gradient: radial-gradient(circle at 15% 10%, #d4f3ff 0%, #b6deff 45%, #95c8fb 100%);
+  --bg-gradient: radial-gradient(circle at 15% 10%, #e4f8ff 0%, #bfdfff 45%, #9ec3ff 100%);
   --text-color: #0d2238;
   --muted-text: #2d4b67;
-  --accent: #006fbf;
-  --card-bg: rgba(255, 255, 255, 0.45);
-  --card-border: rgba(255, 255, 255, 0.7);
+  --accent: #007fd3;
+  --accent-2: #5f4ac7;
+  --card-bg: rgba(255, 255, 255, 0.52);
+  --card-border: rgba(255, 255, 255, 0.74);
   --shadow: 0 20px 35px rgba(47, 106, 160, 0.24);
 }
 
@@ -34,6 +36,7 @@ body {
 
 body {
   background: transparent;
+  line-height: 1.6;
 }
 
 #particles-canvas {
@@ -53,7 +56,7 @@ body > *:not(#particles-canvas) {
 
 .liquid-card {
   border: 1px solid var(--card-border);
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.2), var(--card-bg));
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.25), var(--card-bg));
   box-shadow: var(--shadow);
   backdrop-filter: blur(14px) saturate(150%);
   -webkit-backdrop-filter: blur(14px) saturate(150%);
@@ -91,6 +94,12 @@ body > *:not(#particles-canvas) {
   color: var(--text-color);
   text-decoration: none;
   font-weight: 700;
+  transition: opacity 0.2s ease;
+}
+
+.top-nav a:hover,
+.mobile-nav a:hover {
+  opacity: 0.75;
 }
 
 .floating-controls {
@@ -120,42 +129,92 @@ body > *:not(#particles-canvas) {
   width: min(1200px, calc(100% - 2rem));
   margin: 2rem auto;
   display: grid;
-  grid-template-columns: 1fr minmax(280px, 430px);
+  grid-template-columns: 1fr minmax(280px, 410px);
   gap: 1.5rem;
   align-items: center;
 }
 
 .hero-content {
-  border-radius: 24px;
+  border-radius: 26px;
   padding: clamp(1.4rem, 2.4vw, 2.2rem);
+}
+
+.eyebrow {
+  display: inline-flex;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--card-border);
+  margin-bottom: 1rem;
 }
 
 .hero-content h1 {
   font-family: 'Orbitron', sans-serif;
-  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-size: clamp(1.8rem, 4.1vw, 3rem);
+  line-height: 1.2;
   margin-bottom: 0.75rem;
-  color: var(--accent);
 }
 
 .hero-content p {
   color: var(--muted-text);
-  font-size: clamp(1rem, 2vw, 1.2rem);
-  margin-bottom: 1.3rem;
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  margin-bottom: 1.1rem;
 }
 
-.hero-content .button {
+.hero-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.button {
   display: inline-block;
-  background: linear-gradient(130deg, var(--accent), #8ef6ff);
-  color: #00121c;
-  padding: 0.75rem 1.25rem;
+  padding: 0.72rem 1.15rem;
   border-radius: 12px;
   font-weight: 700;
   text-decoration: none;
 }
 
+.button.primary {
+  background: linear-gradient(120deg, var(--accent), #ccf4ff);
+  color: #052030;
+}
+
+.button.ghost {
+  color: var(--text-color);
+  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.hero-stats {
+  margin-top: 1.2rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+.hero-stats div {
+  border-radius: 12px;
+  border: 1px solid var(--card-border);
+  padding: 0.7rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.hero-stats strong {
+  display: block;
+  font-family: 'Orbitron', sans-serif;
+  color: var(--accent);
+}
+
+.hero-stats span {
+  font-size: 0.82rem;
+  color: var(--muted-text);
+}
+
 .hero-img {
   width: 100%;
-  max-width: 430px;
+  max-width: 410px;
   justify-self: center;
   filter: drop-shadow(0 14px 25px rgba(0, 0, 0, 0.34));
 }
@@ -176,53 +235,46 @@ h2 {
   font-size: clamp(1.5rem, 3vw, 2.1rem);
 }
 
-.game-nav {
-  margin: 1.25rem 0 2rem;
+.section-copy {
+  margin: 0.6rem 0 1.25rem;
+  color: var(--muted-text);
+}
+
+.projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 0.8rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 
-.game-nav button {
-  border: 1px solid var(--card-border);
-  border-radius: 12px;
-  padding: 0.65rem 1rem;
-  font-family: 'Orbitron', sans-serif;
-  color: var(--text-color);
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.07));
-  cursor: pointer;
-}
-
-.game-detail,
+.project-card,
 .transparent-section,
 .contact-card {
   border-radius: 18px;
-  padding: 1.2rem;
-  margin-bottom: 1.1rem;
+  padding: 1.1rem;
   border: 1px solid var(--card-border);
   background: linear-gradient(130deg, rgba(255, 255, 255, 0.2), var(--card-bg));
   box-shadow: var(--shadow);
   backdrop-filter: blur(14px);
 }
 
-.game-detail {
-  display: flex;
-  align-items: center;
-  gap: 1.1rem;
+.project-card h3 {
+  margin-top: 0.8rem;
+  margin-bottom: 0.4rem;
+}
+
+.project-card p {
+  color: var(--muted-text);
+  margin-bottom: 0.6rem;
 }
 
 .game-thumb {
-  width: min(330px, 42vw);
+  width: 100%;
   border-radius: 12px;
   object-fit: cover;
+  aspect-ratio: 16 / 9;
 }
 
-.description-block p {
-  margin: 0.5rem 0 0.9rem;
-  color: var(--muted-text);
-}
-
-.description-block a,
+.project-card a,
 .contact-item {
   color: var(--accent);
   text-decoration: none;
@@ -313,16 +365,11 @@ footer {
   }
 
   .hero-img {
-    max-width: 330px;
+    max-width: 320px;
   }
 
-  .game-detail {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .game-thumb {
-    width: 100%;
+  .hero-stats {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -4,11 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Aka Shakthi – Game Developer Portfolio</title>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
-
   <canvas id="particles-canvas"></canvas>
 
   <div class="floating-controls">
@@ -21,8 +20,8 @@
     <div class="nav-container liquid-card">
       <div id="logo" class="logo">Aka Shakthi</div>
       <nav class="top-nav">
-        <a href="#projects">My Games</a>
-        <a href="#about">About Me</a>
+        <a href="#projects">Projects</a>
+        <a href="#about">About</a>
         <a href="#contact">Contact</a>
       </nav>
       <button class="hamburger" type="button" onclick="toggleMenu()" aria-label="Open menu">☰</button>
@@ -31,167 +30,84 @@
 
   <div id="mobileNav" class="mobile-nav liquid-card">
     <button id="closeNavBtn" aria-label="Close menu">✕</button>
-    <a href="#projects" onclick="toggleMenu()">My Games</a>
-    <a href="#about" onclick="toggleMenu()">About Me</a>
+    <a href="#projects" onclick="toggleMenu()">Projects</a>
+    <a href="#about" onclick="toggleMenu()">About</a>
     <a href="#contact" onclick="toggleMenu()">Contact</a>
     <div class="mobile-social">
       <a href="https://github.com/akashakthi" target="_blank"><img src="img/github.svg" class="icon" alt="GitHub"></a>
-      <a href="#"><img src="img/unity.svg" class="icon" alt="Unity"></a>
       <a href="https://www.linkedin.com/in/aka-shakthi-90b547191/" target="_blank"><img src="img/linkedin.svg" class="icon" alt="LinkedIn"></a>
+      <a href="mailto:akashakthi0@gmail.com"><img src="img/gmail.svg" class="icon" alt="Email"></a>
     </div>
   </div>
   <div id="blur-overlay"></div>
 
   <section class="hero-overlay">
     <div class="hero-content liquid-card interactive-float">
-      <h1>I Develop Games</h1>
-      <p>Creative gameplay & immersive stories.</p>
-      <a href="#projects" class="button">View My Work</a>
+      <p class="eyebrow">Indie Game Developer • Unity Engineer</p>
+      <h1>Building expressive games with strong mechanics and style.</h1>
+      <p>I design and develop game prototypes, jam titles, and production-ready systems for WebGL and mobile.</p>
+      <div class="hero-buttons">
+        <a href="#projects" class="button primary">See Projects</a>
+        <a href="#contact" class="button ghost">Let’s Collaborate</a>
+      </div>
+      <div class="hero-stats">
+        <div><strong>13+</strong><span>Published games</span></div>
+        <div><strong>Unity</strong><span>C# • UI • Gameplay</span></div>
+        <div><strong>WebGL</strong><span>Mobile-ready focus</span></div>
+      </div>
     </div>
     <img src="img/hero-photo.png" class="hero-img" alt="Aka Shakthi">
   </section>
 
   <main>
     <section id="projects">
-      <h2>My Games</h2>
-      <div class="game-nav">
-        <button onclick="scrollToGame('game1')">The Avengers Seed</button>
-        <button onclick="scrollToGame('game2')">Mythwood Garden</button>
-        <button onclick="scrollToGame('game3')">Swaraquest</button>
-        <button onclick="scrollToGame('game4')">Bolos</button>
-        <button onclick="scrollToGame('game5')">Wayahe Turu</button>
-        <button onclick="scrollToGame('game6')">Bunny Crime</button>
-        <button onclick="scrollToGame('game7')">Path to Glory</button>
-        <button onclick="scrollToGame('game8')">Rythm Dash MMTCFest</button>
-        <button onclick="scrollToGame('game9')">Clickhit</button>
-        <button onclick="scrollToGame('game10')">Pride of Republic</button>
-        <button onclick="scrollToGame('game11')">Downdie</button>
-        <button onclick="scrollToGame('game12')">Evadrone</button>
-        <button onclick="scrollToGame('game13')">Keepmoving</button>
-      </div>
+      <h2>Selected Projects</h2>
+      <p class="section-copy">A mix of rhythm, platformer, puzzle, and narrative games built for jams and competitions.</p>
 
-      <div class="game-detail interactive-float" id="game1">
-        <img src="img/the-avengers-seed.jpg" class="game-thumb" alt="The Avengers Seed">
-        <div class="description-block">
+      <div class="projects-grid">
+        <article class="project-card interactive-float">
+          <img src="img/the-avengers-seed.jpg" class="game-thumb" alt="The Avengers Seed">
           <h3>The Avengers Seed</h3>
-          <p>Story-driven platformer made for game jam.</p>
-          <a href="https://aka-shakthi.itch.io/the-avengers-seed" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game2">
-        <img src="img/mythwood-garden.jpg" class="game-thumb" alt="Mythwood Garden">
-        <div class="description-block">
+          <p>Story-driven platformer developed during game jam sprint.</p>
+          <a href="https://aka-shakthi.itch.io/the-avengers-seed" target="_blank">Play on Itch.io</a>
+        </article>
+        <article class="project-card interactive-float">
+          <img src="img/mythwood-garden.jpg" class="game-thumb" alt="Mythwood Garden">
           <h3>Mythwood Garden</h3>
-          <p>Wholesome harvest, grow & design with lore.</p>
-          <a href="https://yaaanbo.itch.io/mythwood-garden" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game3">
-        <img src="img/swaraquest.jpg" class="game-thumb" alt="Swaraquest">
-        <div class="description-block">
+          <p>Cozy harvest-and-design experience with worldbuilding flavor.</p>
+          <a href="https://yaaanbo.itch.io/mythwood-garden" target="_blank">Play on Itch.io</a>
+        </article>
+        <article class="project-card interactive-float">
+          <img src="img/swaraquest.jpg" class="game-thumb" alt="Swaraquest">
           <h3>Swaraquest</h3>
-          <p>Rhythm-based puzzle game using sound cues.</p>
-          <a href="https://aka-shakthi.itch.io/swaraquest" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game4">
-        <img src="img/bolos.jpg" class="game-thumb" alt="Bolos">
-        <div class="description-block">
-          <h3>Bolos</h3>
-          <p>A short interactive narrative with twists.</p>
-          <a href="https://aka-shakthi.itch.io/bolos" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game5">
-        <img src="img/wayahe-turu.jpg" class="game-thumb" alt="Wayahe Turu">
-        <div class="description-block">
-          <h3>Wayahe Turu</h3>
-          <p>Comedy clicker about “sleepiness” + chaos.</p>
-          <a href="https://aka-shakthi.itch.io/wayahe-turu" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game6">
-        <img src="img/bunny-crime.jpg" class="game-thumb" alt="Bunny Crime">
-        <div class="description-block">
-          <h3>Bunny Crime</h3>
-          <p>Funny chaotic mystery game made in jam.</p>
-          <a href="https://aka-shakthi.itch.io/bunny-crime" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game7">
-        <img src="img/path-to-glory.jpg" class="game-thumb" alt="Path to Glory">
-        <div class="description-block">
+          <p>Rhythm puzzle game where sound cues drive player strategy.</p>
+          <a href="https://aka-shakthi.itch.io/swaraquest" target="_blank">Play on Itch.io</a>
+        </article>
+        <article class="project-card interactive-float">
+          <img src="img/path-to-glory.jpg" class="game-thumb" alt="Path to Glory">
           <h3>Path to Glory</h3>
-          <p>Side-scrolling action for competition.</p>
-          <a href="https://aka-shakthi.itch.io/path-to-glory" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game8">
-        <img src="img/rythm-dash-mmtcfest.jpg" class="game-thumb" alt="Rythm Dash MMTCFest">
-        <div class="description-block">
-          <h3>Rythm Dash MMTCFest</h3>
-          <p>Beat-based endless runner for MMTC Festival.</p>
-          <a href="https://aka-shakthi.itch.io/rythm-dash-mmtcfest" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game9">
-        <img src="img/clickhit.jpg" class="game-thumb" alt="Clickhit">
-        <div class="description-block">
-          <h3>Clickhit</h3>
-          <p>Simple clicker game with an aggressive twist.</p>
-          <a href="https://aka-shakthi.itch.io/clickhit" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game10">
-        <img src="img/pride-of-republic.jpg" class="game-thumb" alt="Pride of Republic">
-        <div class="description-block">
+          <p>Action side-scroller created for a competitive development event.</p>
+          <a href="https://aka-shakthi.itch.io/path-to-glory" target="_blank">Play on Itch.io</a>
+        </article>
+        <article class="project-card interactive-float">
+          <img src="img/pride-of-republic.jpg" class="game-thumb" alt="Pride of Republic">
           <h3>Pride of Republic</h3>
-          <p>Political turn-based strategy game. Restore national integrity.</p>
-          <a href="https://aka-shakthi.itch.io/pride-of-republic" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game11">
-        <img src="img/downdie.jpg" class="game-thumb" alt="Downdie">
-        <div class="description-block">
-          <h3>Downdie</h3>
-          <p>A rage game you climb... but downward.</p>
-          <a href="https://aka-shakthi.itch.io/downdie" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game12">
-        <img src="img/evadrone.jpg" class="game-thumb" alt="Evadrone">
-        <div class="description-block">
-          <h3>Evadrone</h3>
-          <p>Evade obstacles and drone logic in a confined space.</p>
-          <a href="https://at-sauri.itch.io/evadrone" target="_blank">▶️ Play on Itch.io</a>
-        </div>
-      </div>
-
-      <div class="game-detail interactive-float" id="game13">
-        <img src="img/keepmoving.jpg" class="game-thumb" alt="Keepmoving">
-        <div class="description-block">
+          <p>Turn-based political strategy game about restoring national integrity.</p>
+          <a href="https://aka-shakthi.itch.io/pride-of-republic" target="_blank">Play on Itch.io</a>
+        </article>
+        <article class="project-card interactive-float">
+          <img src="img/keepmoving.jpg" class="game-thumb" alt="Keepmoving">
           <h3>Keepmoving</h3>
-          <p>Endless rhythm runner with pixel vibes.</p>
-          <a href="https://aka-shakthi.itch.io/keepmoving" target="_blank">▶️ Play on Itch.io</a>
-        </div>
+          <p>Fast-paced endless runner with rhythm timing and pixel energy.</p>
+          <a href="https://aka-shakthi.itch.io/keepmoving" target="_blank">Play on Itch.io</a>
+        </article>
       </div>
     </section>
 
     <section id="about" class="transparent-section contact-card interactive-float">
       <h2>About Me</h2>
       <p>
-        Hi, I'm Aka Shakthi — a passionate indie game developer and tech artist currently pursuing my studies while building immersive, interactive experiences. I specialize in creating modular UI systems, smooth gameplay loops, and scalable architectures using Unity and C#. Most of my work is tailored for WebGL and mobile platforms, combining clean code with artistic sensibility.
+        Hi, I’m Aka Shakthi — an indie game developer and tech artist passionate about combining clean architecture with playful experiences. I focus on modular UI systems, responsive gameplay loops, and maintainable Unity workflows for WebGL and mobile projects.
       </p>
     </section>
   </main>
@@ -220,7 +136,7 @@
   </section>
 
   <footer>
-    <p>© 2026 Aka Shakthi. All rights reserved.</p>
+    <p>© 2026 Aka Shakthi. Crafted with Unity mindset and indie spirit.</p>
   </footer>
 
   <script src="js/script.js"></script>


### PR DESCRIPTION
### Motivation
- Align the portfolio visuals with a cleaner modern reference to improve first impression and scanability. 
- Surface key developer info and CTAs in the hero to drive engagement. 
- Make the projects section easier to browse by replacing a long stacked list with a responsive card grid.

### Description
- Reworked the hero: added an eyebrow role badge, stronger headline, dual CTAs, and a three-item stats row in `index.html` to strengthen the lead section. 
- Converted the long per-project stacked layout into a responsive `projects-grid` of `.project-card` articles and simplified copy in `index.html` for selected projects. 
- Updated visual tokens and layout in `css/style.css` (color accents, `--accent-2`, gradients, spacing, `line-height`, card radius, button styles, and responsive tweaks) to produce a softer glassmorphism look while preserving existing particle and theme behavior. 
- Small content and navigation tweaks in `index.html` (labels, mobile social links and ordering, font weight adjustments) while leaving the interactive JS logic intact.

### Testing
- Ran `node --check js/script.js` which completed successfully. 
- Attempted HTML validation with `xmllint --html --noout index.html`, but `xmllint` is not available in the environment so the check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0488273cc8323835f64d5da059a84)