### PR TITLE
Move theme toggle to circular floating button and pin header on scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,6 +44,7 @@ body {
 
 body {
   background: transparent;
+  padding-top: 5.4rem;
 }
 
 #particles-canvas {
@@ -95,9 +96,11 @@ body > *:not(#particles-canvas) {
 
 .hero {
   padding-top: 0.8rem;
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 12;
+  left: 0;
+  width: 100%;
+  z-index: 30;
   transition: padding 0.22s ease;
 }
 
@@ -157,11 +160,9 @@ body > *:not(#particles-canvas) {
 
 .floating-controls {
   position: fixed;
-  right: 1rem;
+  right: 5.8rem;
   bottom: 1rem;
   display: flex;
-  flex-direction: row;
-  gap: 0.6rem;
   z-index: 999;
 }
 
@@ -178,12 +179,19 @@ body > *:not(#particles-canvas) {
   font-size: 1.15rem;
 }
 
-#themeToggle {
+.floating-theme-button {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
   width: 56px;
   height: 56px;
   padding: 0;
   font-size: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   box-shadow: 0 10px 24px rgba(10, 17, 34, 0.35);
+  z-index: 1000;
 }
 
 .hero-overlay {
@@ -465,6 +473,16 @@ footer {
 
   .hamburger {
     display: inline-flex;
+  }
+
+  .floating-controls {
+    right: 5.2rem;
+    bottom: 0.9rem;
+  }
+
+  .floating-theme-button {
+    right: 0.9rem;
+    bottom: 0.9rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
 
   <canvas id="particles-canvas"></canvas>
 
+  <button id="themeToggle" class="floating-theme-button" aria-label="Toggle day and night mode">🌙</button>
+
   <div class="floating-controls">
-    <button id="themeToggle" aria-label="Toggle day and night mode">🌙</button>
     <button id="soundToggle" aria-label="Toggle background sound">🔊</button>
   </div>
   <audio id="bg-music" src="music/LateNightGameDev.mp3" autoplay loop></audio>


### PR DESCRIPTION
### Motivation
- Make the night-mode control a distinct circular button at the bottom-right so it doesn't share the header controls and avoids overlap with the sound button.
- Keep the header visually anchored while scrolling so the nav stays accessible (user requested header remain held/anchored on scroll down).
- Prevent page content from being hidden behind the newly fixed header by adding appropriate top spacing.

### Description
- Updated `index.html` to move the theme toggle out of the floating control group and render it as a separate `button` with class `floating-theme-button` positioned at the bottom-right.
- Modified `css/style.css` to change `.hero` from `position: sticky` to `position: fixed` with `left: 0`, `width: 100%` and increased `z-index`, and added `body { padding-top: 5.4rem; }` to avoid content overlap.
- Added `.floating-theme-button` styles (fixed position, circular 56px size, z-index) and adjusted `.floating-controls` placement to `right: 5.8rem` with responsive tweaks for mobile viewports.
- Left JavaScript behavior unchanged and verified the existing `#themeToggle` selector will continue to work with the relocated button.

### Testing
- Ran `git diff --check` to validate there are no obvious whitespace issues and it passed.
- Ran `git status --short` to confirm `index.html` and `css/style.css` were modified as expected.
- No automated test suite is configured for this static site, so changes were validated by reviewing the updated markup and styles to ensure the theme toggle and header behavior remain functional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0531ba810832381f5419c3921aa9d)