### PR TITLE
Refine header behavior and reposition day/night toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,9 +7,9 @@
   --text-color: #f4fbff;
   --muted-text: #bdd5e4;
   --accent: #8cf6ff;
-  --card-bg: rgba(255, 255, 255, 0.07);
-  --card-border: rgba(169, 235, 255, 0.28);
-  --shadow: 0 18px 40px rgba(1, 6, 18, 0.62);
+  --card-bg: rgba(9, 16, 30, 0.74);
+  --card-border: rgba(125, 186, 230, 0.22);
+  --shadow: 0 18px 40px rgba(1, 4, 12, 0.78);
   --glass-highlight: rgba(208, 245, 255, 0.35);
   --neon-glow: 0 0 14px rgba(130, 245, 255, 0.8), 0 0 30px rgba(140, 91, 255, 0.45);
 }
@@ -102,8 +102,7 @@ body > *:not(#particles-canvas) {
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 30;
-  transition: padding 0.22s ease;
+  z-index: 1100;
 }
 
 .nav-container {
@@ -115,21 +114,6 @@ body > *:not(#particles-canvas) {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  transition: transform 0.22s ease, box-shadow 0.22s ease, background 0.22s ease;
-}
-
-.hero.scrolled {
-  padding-top: 0.45rem;
-}
-
-.hero.scrolled .nav-container {
-  transform: translateY(-2px);
-  box-shadow: 0 14px 34px rgba(5, 13, 28, 0.42);
-}
-
-.brand-stack {
-  display: grid;
-  gap: 0.06rem;
 }
 
 .logo {
@@ -137,15 +121,6 @@ body > *:not(#particles-canvas) {
   font-size: 1.1rem;
   letter-spacing: 0.05em;
   cursor: pointer;
-}
-
-.header-role,
-.mobile-role {
-  font-size: 0.72rem;
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
-  color: var(--muted-text);
-  font-weight: 700;
 }
 
 .top-nav {
@@ -162,8 +137,8 @@ body > *:not(#particles-canvas) {
 
 .floating-controls {
   position: fixed;
-  right: 5.8rem;
-  bottom: 1rem;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
   display: flex;
   z-index: 999;
 }
@@ -183,8 +158,8 @@ body > *:not(#particles-canvas) {
 
 .floating-theme-button {
   position: fixed;
-  right: 1rem;
-  bottom: 1rem;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
   width: 56px;
   height: 56px;
   padding: 0;
@@ -194,6 +169,10 @@ body > *:not(#particles-canvas) {
   justify-content: center;
   box-shadow: 0 10px 24px rgba(10, 17, 34, 0.35);
   z-index: 1000;
+}
+
+.floating-controls {
+  transform: translateX(calc(-56px - 0.85rem));
 }
 
 .hero-overlay {
@@ -403,10 +382,6 @@ footer {
   gap: 0.9rem;
 }
 
-.mobile-role {
-  margin-top: 0.7rem;
-}
-
 #closeNavBtn {
   position: absolute;
   top: 1rem;
@@ -480,13 +455,16 @@ footer {
   }
 
   .floating-controls {
-    right: 5.2rem;
-    bottom: 0.9rem;
+    right: max(0.85rem, env(safe-area-inset-right));
+    bottom: max(0.85rem, env(safe-area-inset-bottom));
+    transform: translateX(calc(-52px - 0.65rem));
   }
 
   .floating-theme-button {
-    right: 0.9rem;
-    bottom: 0.9rem;
+    right: max(0.85rem, env(safe-area-inset-right));
+    bottom: max(0.85rem, env(safe-area-inset-bottom));
+    width: 52px;
+    height: 52px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -20,10 +20,7 @@
 
   <header class="hero">
     <div class="nav-container liquid-card">
-      <div class="brand-stack">
-        <div id="logo" class="logo">Aka Shakthi</div>
-        <span class="header-role">Game Programmer</span>
-      </div>
+      <div id="logo" class="logo">Aka Shakthi</div>
       <nav class="top-nav">
         <a href="#projects">My Games</a>
         <a href="#about">About Me</a>
@@ -38,7 +35,6 @@
     <a href="#projects" onclick="toggleMenu()">My Games</a>
     <a href="#about" onclick="toggleMenu()">About Me</a>
     <a href="#contact" onclick="toggleMenu()">Contact</a>
-    <span class="mobile-role">Game Programmer</span>
     <div class="mobile-social">
       <a href="https://github.com/akashakthi" target="_blank"><img src="img/github.svg" class="icon" alt="GitHub"></a>
       <a href="#"><img src="img/unity.svg" class="icon" alt="Unity"></a>

--- a/js/script.js
+++ b/js/script.js
@@ -83,12 +83,6 @@ function setTheme(theme) {
   themeToggle.textContent = theme === 'day' ? '☀️' : '🌙';
 }
 
-function updateHeaderState() {
-  const header = document.querySelector('.hero');
-  if (!header) return;
-  header.classList.toggle('scrolled', window.scrollY > 18);
-}
-
 document.addEventListener('DOMContentLoaded', () => {
   const audio = document.getElementById('bg-music');
   const soundToggle = document.getElementById('soundToggle');
@@ -97,7 +91,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   setTheme(savedTheme);
   setupInteractiveCards();
-  updateHeaderState();
 
   audio.volume = 0.4;
   audio.play().catch(() => {
@@ -119,8 +112,6 @@ document.addEventListener('DOMContentLoaded', () => {
     setTheme(current === 'night' ? 'day' : 'night');
   });
 });
-
-window.addEventListener('scroll', updateHeaderState, { passive: true });
 
 function scrollToGame(id) {
   const el = document.getElementById(id);


### PR DESCRIPTION
### Motivation
- Keep the header pinned and visually stable (no pop/scroll transitions) so it doesn't shift while scrolling.
- Move the day/night toggle and sound control away from the screen edge and make them responsive/safe-area aware so they never sit flush to the corner.
- Simplify branding to show only the name and avoid repeating the role in both header and mobile nav for a cleaner layout.
- Increase the contrast of dark-mode panels so cards look darker and heavier in night theme.

### Description
- HTML: simplified the header branding to a single `div#logo` and removed the inline role labels in the header and mobile nav (`index.html`).
- CSS: darkened night-mode panel variables (`--card-bg`, `--card-border`, `--shadow`) and raised the header's `z-index` so it stays on top, removed the header scrolled animation, and repositioned floating controls using `env(safe-area-inset-*)` with responsive transforms and size adjustments for mobile (`css/style.css`).
- JS: removed the header scroll-state updater and its scroll listener so the header no longer toggles a "scrolled" class (`js/script.js`).
- Layout: adjusted floating theme and control sizes/offsets so the toggle sits at the bottom-right with a safe gap from the edges and scales on smaller screens (`css/style.css`).

### Testing
- Ran codebase search for affected tokens with `rg -n "header-role|mobile-role|scrolled|updateHeaderState|brand-stack" index.html css/style.css js/script.js` to confirm removals and updates, and the search returned expected results.
- Inspected the diffs for `index.html`, `css/style.css`, and `js/script.js` to verify the exact edits and that the header-related JS and markup were removed as intended.
- Verified the working tree contains the updated files and that the most recent change metadata reflects the UI updates.
- No automated visual tests available in this environment; all automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0560e1d248323a382b17265c70529)